### PR TITLE
Switch default server to paste.debian.net

### DIFF
--- a/grml-paste
+++ b/grml-paste
@@ -12,7 +12,7 @@ import sys
 from xmlrpc.client import ServerProxy
 
 # program defaults
-DEFAULT_SERVER = "https://paste.grml.org/server.pl"
+DEFAULT_SERVER = "https://paste.debian.net/server.pl"
 
 
 class ActionFailedException(Exception):


### PR DESCRIPTION
Due to lack of resources, paste.grml.org will be shut down. Switch the default server to a maintained instance.