### PR TITLE
GHA: package-build: do not fail on forks for comments

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -45,6 +45,7 @@ jobs:
             debian/artifacts/*.tar.*
       - name: Comment PR with artifact link
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
Commenting is apparently not possible if the PR originated on a fork. Ignore the error then.